### PR TITLE
Use the message no arg during Retr instead of 1

### DIFF
--- a/client.go
+++ b/client.go
@@ -197,7 +197,7 @@ func (c *Client) Rset() error {
 
 // Retr downloads the given message and returns it as a mail.Message object.
 func (c *Client) Retr(msg int) (*enmime.Envelope, error) {
-	if _, err := c.conn.Cmd("%s 1", CommandRetrieve); err != nil {
+	if _, err := c.conn.Cmd("%s %d", CommandRetrieve, msg); err != nil {
 		return nil, fmt.Errorf("failed at RETR command: %w", err)
 	}
 


### PR DESCRIPTION
Retr method is always using 1 i.e retrieving 1st message instead of using "msg" variable already being passed to it.